### PR TITLE
Ack on control

### DIFF
--- a/draft-krasic-quic-qcram.md
+++ b/draft-krasic-quic-qcram.md
@@ -124,11 +124,31 @@ request / push streams.
 
 ## HEADER_ACK
 
-The HEADER_ACK frame (type=0x8) is sent from the decoder to the encoder when the
-decoder has fully processed a header block on a stream.  It is used by the
-encoder to determine whether subsequent indexed representations that might
-reference that block are vulnerable to HoL blocking.  The HEADER_ACK frame does
-not define any flags, and has no payload.
+The HEADER_ACK frame (type=0x8) is sent from the decoder to the encoder on the
+Control Stream when the decoder has fully processed a header block.  It is used
+by the encoder to determine whether subsequent indexed representations that
+might reference that block are vulnerable to HoL blocking.
+
+The HEADER_ACK frame indicates the stream on which the header block was
+processed by encoding the Stream ID as a variable-length integer. The same
+Stream ID can be identified multiple times, as multiple header-containing blocks
+can be sent on a single stream in the case of intermediate responses, trailers,
+pushed requests, etc. as well as on the Control Streams.
+
+Since header frames on each stream are received and processed in order, this
+gives the encoder precise feedback on which header blocks within a stream have
+been fully processed.  This information can then be used to correctly track
+outstanding stream references to checkpoints.
+
+~~~~~~~~~~
+  0   1   2   3   4   5   6   7
++---+---+---+---+---+---+---+---+
+|        Stream ID [i]          |
++---+---------------------------+
+~~~~~~~~~~
+{: title="HEADER_ACK frame"}
+
+The HEADER_ACK frame does not define any flags.
 
 # HPACK extensions
 

--- a/draft-krasic-quic-qcram.md
+++ b/draft-krasic-quic-qcram.md
@@ -18,149 +18,117 @@ author:
     org: Google
     email: ckrasic@google.com
 
-normative:
-
-  QUIC-TRANSPORT:
-    title: "QUIC: A UDP-Based Multiplexed and Secure Transport"
-    date: {DATE}
-    author:
-      -
-        ins: J. Iyengar
-        name: Jana Iyengar
-        org: Google
-        role: editor
-      -
-        ins: M. Thomson
-        name: Martin Thomson
-        org: Mozilla
-        role: editor
-
-  QUIC-HTTP:
-    title: "Hypertext Transfer Protocol (HTTP) over QUIC"
-    date: {DATE}
-    author:
-      -
-        ins: M. Bishop
-        name: Mike Bishop
-        org: Microsoft
-        role: editor
 
 --- abstract
 
-The design of the core QUIC transport and the mapping of HTTP semantics over it
-subsume many HTTP/2 features, prominent among them stream multiplexing and HTTP
-header compression.  A key advantage of the QUIC transport is it provides
-stream multiplexing free of HoL blocking between streams, while in HTTP/2
-multiplexed streams can suffer HoL blocking primarily due to HTTP/2's layering
-above TCP. However if HPACK is used for header compression, HTTP over
-QUIC is still vulnerable to HoL blocking, because of how HPACK exploits header
-redundancies between multiplexed HTTP transactions.  This draft defines QCRAM, a
-variation of HPACK and mechanisms in the QUIC HTTP mapping that allow QUIC
-implementations the flexibility to avoid header-compression induced HoL
-blocking.
+The design of the core QUIC transport subsumes many HTTP/2 features, prominent
+among them stream multiplexing.  A key advantage of the QUIC transport is stream
+multiplexing free of head-of-line (HoL) blocking between streams. In HTTP/2,
+multiplexed streams can suffer HoL blocking due to TCP.
+
+If HTTP/2's HPACK is used for header compression, HTTP/QUIC is still vulnerable
+to HoL blocking, because of HPACK's assumption of in-order delivery.  This draft
+defines QCRAM, a variation of HPACK and mechanisms in the HTTP/QUIC mapping that
+allow the flexibility to avoid header-compression-induced HoL blocking.
 
 --- middle
 
 # Introduction
 
 The QUIC transport protocol was designed from the outset to support HTTP
-semantics, and its design subsumes most of the features of HTTP/2.  Two of those
-features, stream multiplexing and header compression come into some conflict in
-QUIC.  A key goal of the design of QUIC is to improve stream multiplexing
-relative to HTTP/2, by eliminating HoL (head of line) blocking that can occur in
-HTTP/2.  HoL blocking can happen because HTTP/2 streams are multiplexed onto a
-single TCP connection with its in-order semantics.  QUIC can maintain
-independence between streams because it implements core transport functionality
-in a fully stream-aware manner.  However, the HTTP over QUIC mapping is still
-subject to HoL blocking if HPACK is used directly as in HTTP/2.  HPACK exploits
-multiplexing for greater compression, shrinking the representation of headers
-that have appeared earlier on the same connection.  In the context of QUIC, this
-imposes a vulnerability to HoL blocking as will be described more below
-({{hol-example}}).
+semantics, and its design subsumes many of the features of HTTP/2.  QUIC's
+stream multiplexing comes into some conflict with  header compression.  A key
+goal of the design of QUIC is to improve stream multiplexing relative to HTTP/2
+by eliminating HoL (head of line) blocking, which can occur in HTTP/2.  HoL
+blocking can happen because all HTTP/2 streams are multiplexed onto a single TCP
+connection with its in-order semantics.  QUIC can maintain independence between
+streams because it implements core transport functionality in a fully
+stream-aware manner.  However, the HTTP/QUIC mapping is still subject to HoL
+blocking if HPACK is used directly.  HPACK exploits multiplexing for greater
+compression, shrinking the representation of headers that have appeared earlier
+on the same connection.  In the context of QUIC, this imposes a vulnerability to
+HoL blocking (see {{hol-example}}).
 
-QUIC is described in {{QUIC-TRANSPORT}}.  The HTTP over QUIC mapping is
-described in {{QUIC-HTTP}}. For a full description of HTTP/2, see {{!RFC7540}}.
-The description of HPACK is {{!RFC7541}}.
+QUIC is described in {{?QUIC-TRANSPORT=I-D.ietf-quic-transport}}.  The HTTP/QUIC
+mapping is described in {{!QUIC-HTTP=I-D.ietf-quic-http}}. For a full
+description of HTTP/2, see {{?RFC7540}}. The description of HPACK is
+{{!RFC7541}}, with important terminology in Section 1.3.
 
-# QCRAM overview
+QCRAM modifies HPACK to allow correctness in the presence of out-of-order
+delivery, with flexibility for implementations to balance between resilience
+against HoL blocking and optimal compression ratio.  The design goals are to
+closely approach the compression ration of HPACK with substantially less
+head-of-line blocking under the same loss conditions.
 
-Readers may wish to refer to {{!RFC7541}} Section 1.3 to review HPACK
-terminology, and {{QUIC-HTTP}}, Sections 4 on "HTTP over QUIC stream mapping"
-and 4.2.1 on "Header Compression".  QCRAM extensions to HPACK allow correctness
-in the presence of out-of-order delivery, with flexibility to balance between
-resilience against HoL blocking and compression ratio.
-
-QCRAM is intended to be a relatively non-intrusive extension to HPACK, an
+QCRAM is intended to be a relatively non-intrusive extension to HPACK; an
 implementation should be easily shared within stacks supporting both HTTP/2 over
-(TLS+)TCP and HTTP over QUIC.
+(TLS+)TCP and HTTP/QUIC.
 
-## Example of HoL blocking {#hol-example}
+## Head-of-Line Blocking in HPACK {#hol-example}
 
-The following is an example of how HPACK can induce HoL blocking in QUIC. Assume
-two HTTP message exchange streams `A` and `B`, and corresponding header blocks `HA`
-and `HB`. Stream `B` experiences HoL blocking due to `A` as follows:
+HPACK enables several types of header representations, one of which also adds
+the header to a dynamic table of header values.  These values are then available
+for reuse in subsequent header blocks simply by referencing the entry number in
+the table.
 
-1. HPACK encodes header field `HB[i]` using an index that refers to a table
-   entry that resulted from header field `HA[j]`.
-2. `HA` and `HB` are delivered via distinct packets that are inflight in the
-   same round trip.
-3. `HB`'s packet is delivered but `HA`'s is dropped.  HPACK can not decode `HB`
-   until `HA`'s packet is successfully retransmitted.
+If the packet containing a header is lost, that stream cannot complete header
+processing until the packet is retransmitted.  This is unavoidable. However,
+other streams which rely on the state created by that packet *also* cannot make
+progress. This is the problem which QUIC solves in general, but which is
+reintroduced by HPACK when the loss includes a HEADERS frame.
 
-## How QCRAM minimizes HoL blocking {#overview-hol-avoidance}
+## Avoiding Head-of-Line Blocking in HTTP/QUIC {#overview-hol-avoidance}
 
-Continuing the example, QCRAM's approach is as follows.
+In the example above, the second stream contained a reference to data
+which might not yet have been processed by the recipient.  Such references
+are called "vulnerable," because the loss of a different packet can keep
+the reference from being usable.
 
-1. `HB[i]` will not introduce HoL blocking if `HA` has been acknowledged,
-   otherwise it is vulnerable.  A new HQ frame type HEADERS_ACK is defined (see
-   {{hq-frames}}).  When the decoder has processed a header block, HEADERS_ACK
-   is sent from the decoder back to the encoder.
-
-The encoder can choose on a per header block basis whether to favor higher
-compression ratio or HoL resilience, signaled by the BLOCKING flag in HEADERS and
+The encoder can choose on a per-header-block basis whether to favor higher
+compression ratio (by permitting vulnerable references) or HoL resilience (by
+avoiding them). This is signaled by the BLOCKING flag in HEADERS and
 PUSH_PROMISE frames (see {{hq-frames}}).
 
-If HB contains no vulnerable header fields, BLOCKING MUST be 0.
+If a header block contains no vulnerable header fields, BLOCKING MUST be 0.
+This implies that the header fields are represented either as references
+to dynamic table entries which are known to have been received, or as
+Literal header fields (see {{RFC7541}} Section 6.2).
 
-If BLOCKING is not set, then for each `HB[i]` that is vulnerable:
+If a header block contains any header field which references dynamic table
+state which the peer might not have received yet, the BLOCKING flag MUST be
+set.  If the peer does not yet have the appropriate state, such blocks
+might not be processed on arrival.
 
-2. `HB[i]` is represented with one of the Literal variants (see {{RFC7541}}
-    Section 6.2), trading lower compression ratio for HoL resilience.
+The header block contains a prefix ({{absolute-index}}). This prefix contains
+table offset information that establishes total ordering among all headers,
+regardless of reordering in the transport (see {{overview-absolute}}).  In
+blocking mode, the prefix additionally identifies the minimum state required to
+process any vulnerable references in the header block (see `Depends` in Section
+{{overview-absolute}}).  When the necessary state has arrived, the header block
+can be processed. Notice that while blocked, HB's header field data remains in
+stream B's flow control window.
 
-If BLOCKING is set then HB is encoded in blocking mode:
-
-3. `HB[i]` is represented with an Indexed Representation.  This favors
-    compression ratio.
-
-In blocking mode, after reading HB's prefix stream B might block.  Stream B
-proceeds with reading and processing the rest of HB only once all HB's
-dependencies are satisfied.  The header prefix contains table offset information
-that establishes total ordering among all headers, regardless of reordering in
-the transport (see {{absolute-index}}).  In blocking mode, the prefix
-additionally identifies the largest (absolute) index I that HB depends on (see
-`Depends` in Section {{overview-absolute}}).  HB's dependencies are satisfied
-when all entries less than or equal to I have been inserted into the table.
-Notice that while blocked, HB's header field data remains in stream B's flow
-control window.
 
 # HTTP over QUIC mapping extensions {#hq-frames}
 
 ## HEADERS and PUSH_PROMISE
 
-HEADERS and PUSH_PROMISE frames define a new flag BLOCKING (0x01): Indicates the
-stream might need to wait for dependent headers before processing.  If 0, the
-header can always be processed immediately upon receipt.
+HEADERS and PUSH_PROMISE frames define a new flag.
+
+BLOCKING (0x01):
+: Indicates the stream might need to wait for dependent headers before
+  processing.  If 0, the frame can be processed immediately upon receipt.
 
 HEADERS frames can be sent on the Connection Control Stream as well as on
 request / push streams.
 
 ## HEADER_ACK
 
-The HEADER_ACK frame (type=0x8) is sent by the decoder side to the encoder when
-a the decoder has fully processed a header block.  It is used by the encoder to
-determine whether subsequent indexed representations that might reference that
-block are vulnerable to HoL blocking.  The HEADER_ACK frame does not define any
-flags, and has no payload.
+The HEADER_ACK frame (type=0x8) is sent from the decoder to the encoder when the
+decoder has fully processed a header block on a stream.  It is used by the
+encoder to determine whether subsequent indexed representations that might
+reference that block are vulnerable to HoL blocking.  The HEADER_ACK frame does
+not define any flags, and has no payload.
 
 # HPACK extensions
 
@@ -178,11 +146,12 @@ the headers for an HTTP request or response.
 ## Header Block Prefix {#absolute-index}
 
 In HEADERS and PUSH_PROMISE frames, HPACK Header data are prefixed by a pair of
-integers pair of integers: `Fill` and the `Evictions`. `Fill` is the number of
-entries in the table, and `Evictions` is the cumulative number entries that have
-been evicted from the table.  Their sum is the cumulative number of entries
-inserted before the following header block was encoded.  Each is encoded as a
-single HPACK integer (8-bit prefix):
+integers: `Fill` and the `Evictions`.
+
+`Fill` is the number of entries in the table, and `Evictions` is the cumulative
+number of entries that have been evicted from the table.  Their sum is the
+cumulative number of entries inserted before the following header block was
+encoded.  Each is encoded as a single 8-bit prefix integer:
 
 ~~~~~~~~~~  drawing
     0 1 2 3 4 5 6 7
@@ -197,7 +166,7 @@ single HPACK integer (8-bit prefix):
 {{overview-absolute}} describes the role of `Fill` and {{evictions}} covers the
 role of `Evictions`.
 
-When BLOCKING flag is 0x1, a the prefix additionally contains a third HPACK
+When the BLOCKING flag is 0x1, a the prefix additionally contains a third HPACK
 integer (8-bit prefix) 'Depends':
 
 ~~~~~~~~~~  drawing
@@ -213,55 +182,58 @@ integer (8-bit prefix) 'Depends':
 {:#fig-prefix-long title="Absolute indexing (BLOCKING=0x1)"}
 
 Depends is used to identify header dependencies, namely the largest table entry
-referred to by (indexed representations within) the following header block, its usage
-is described in {{overview-hol-avoidance}}.  The largest entry index is
-`Evictions + Fill - Depends`.
+referred to by indexed representations within the following header block.  Its
+usage is described in {{overview-hol-avoidance}}.  The largest index referenced
+is `Evictions + Fill - Depends`.
 
 ## Hybrid absolute-relative indexing {#overview-absolute}
 
 HPACK indexed entries refer to an entry by its current position in the dynamic
-table.
-As [Figure 1 of RFC7541](https://tools.ietf.org/html/rfc7541#section-2.3.3)
-illustrates, newest entries have smallest indices, and oldest entries are
-evicted first if the table is full.  Under this scheme, each insertion to the
-table causes the index of all existing entries to change (implicitly).  Implicit
-index updates are acceptable for HTTP/2 because TCP is totally ordered, but it
-is is problematic in the out-of-order context of QUIC.
+table.  As Figure 1 of {{!RFC7541}} illustrates, newer entries have smaller
+indices, and older entries are evicted first if the table is full.  Under this
+scheme, each insertion to the table causes the index of all existing entries to
+change (implicitly).  Implicit index updates are acceptable for HTTP/2 because
+TCP is totally ordered, but are problematic in the out-of-order context of
+QUIC.
 
 QCRAM uses a hybrid absolute-relative indexing approach.  The prefix defined in
 {{absolute-index}} is used by the decoder to interpret all subsequent HPACK
 instructions at absolute positions for indexed lookups and insertions.
 
-Since QCRAM handles blocking at the stream level, it is an error if the HPACK
-decoder encounters an indexed representation that refers to an entry missing
-from the table, and the connection MUST be closed with the
+Since QCRAM handles blocking at the header block level, it is an error if the
+HPACK decoder encounters an indexed representation that refers to an entry
+missing from the table, and the connection MUST be closed with the
 `HTTP_HPACK_DECOMPRESSION_FAILED` error code.
 
 ## Preventing Eviction Races {#evictions}
-Due to out of order arrival, QCRAM's eviction algorithm requires changes
+
+Due to out-of-order arrival, QCRAM's eviction algorithm requires changes
 (relative to HPACK) to avoid the possibility that an indexed representation is
-decoded after the referenced entry is already evicted.  QCRAM employs a
+decoded after the referenced entry has already been evicted.  QCRAM employs a
 two-phase eviction algorithm, in which the encoder will not evict entries that
 have outstanding (unacknowledged) references.  The QCRAM encoder maintains a
 counter as entries are evicted, which is the cumulative number of evictions so
 far, `Evictions` ({{absolute-index}}).  On arrival at the decoder, if
-`Evictions` is higher than previously seen, the decoder MUST evict all entries
-at or below.  Unlike HPACK where the decoder follows the same logic as the
-encoder to perform evictions, in QCRAM the decoder evicts exclusively based on
-the encoder's explicit guidance.
+`Evictions` is higher than previously seen, the decoder MUST evict the
+appropriate number of entries.  Unlike HPACK, where the decoder follows the same
+logic as the encoder to perform evictions, in QCRAM the decoder evicts
+exclusively based on the encoder's explicit guidance.
 
 ### Blocked Evictions
-In some cases, the encoder must forgo eviction by selecting a literal
-representation (blocked eviction), namely in the event that the entry subject to
-eviction *is* referenced by one or more unacknowledged header frames. To assure
-that the blocked eviction case is rare, a form of thresholding MAY be applied
-that constrains selection of Indexed representations, such that the oldest
-entries in the dynamic table will largely be evictable.  The constraint is
-applied when encoding header fields: comparing the cumulative position (in
-bytes) of the matching entry to a threshold, categorizing oldest entries (past
-threshold) as at-risk.  Avoiding references to at-risk entries, the
-encoder SHOULD use an Indexed-Duplicate representation instead (see
-{{indexed-duplicate}}).
+
+The decoder MUST NOT permit an entry to be evicted while a reference to that entry remains
+unacknowledged.  If a new header to be inserted into the dynamic table would cause
+the eviction of such an entry, the encoder MUST NOT emit the insert instruction
+until the reference has been processed by the decoder and acknowledged.
+
+The encoder can emit a literal representation for the new header in order to
+avoid encoding delays, and MAY insert the header into the table later if
+desired.
+
+To ensure that the blocked eviction case is rare, references to the oldest
+entries in the dynamic table SHOULD be avoided.  When one of the oldest entries
+in the table is still actively used for references, the encoder SHOULD emit an
+Indexed-Duplicate representation instead (see {{indexed-duplicate}}).
 
 ## Refreshing Entries with Duplication {#indexed-duplicate}
 
@@ -273,13 +245,12 @@ encoder SHOULD use an Indexed-Duplicate representation instead (see
 ~~~~~~~~~~
 {:#fig-index-with-duplication title="Indexed Header Field with Duplication"}
 
-*Indexed-Duplicates* are treated as an Indexed Header Field Representation (see
-{{!RFC7541}} Section 6.1), additionally inserting a new duplicate entry.
-{{RFC7541}} allows duplicate HPACK table entries, that is entries that have the
-same name and value.
+*Indexed-Duplicates* insert a new entry into the dynamic table which duplicates
+an existing entry. {{RFC7541}} allows duplicate HPACK table entries, that is
+entries that have the same name and value.
 
-*Figure 2 annexes the representation for HPACK Dynamic Table Size Update (see
- Section 6.3 of RFC7541), which is not supported by HTTP over QUIC.*
+This replaces the HPACK instruction for Dynamic Table Size Update (see Section
+6.3 of {{RFC7541}}, which is not supported by HTTP over QUIC.
 
 ### Mandatory Entry De-duplication {#de-duplication}
 
@@ -295,26 +266,30 @@ in conjunction with reference counted pointers to strings would be typical.
 # Performance considerations
 
 ## Speculative table updates {#speculative-updates}
-Implementations can *speculatively* send header frames on the HTTP Connection
-Control Stream.  Such headers would not be associated with any HTTP transaction,
-but could be used strategically to improve performance.  For instance, the
+
+Implementations can *speculatively* send header frames on the HTTP Control
+Streams which are not needed for any current HTTP request or response.  Such
+headers could be used strategically to improve performance.  For instance, the
 encoder might decide to *refresh* by sending Indexed-Duplicate representations
 for popular header fields ({{absolute-index}}), ensuring they have small indices
 and hence minimal size on the wire.
 
 ## Fixed overhead.
+
 HPACK defines overhead as 32 bytes ({{!RFC7541}} Section 4.1).  QCRAM adds some
 per-entry state, to track acknowledgment status and eviction reference count,
 and requires mechanisms to de-duplicate strings.  A larger value than 32 might
 be more accurate for QCRAM.
 
 ## Co-ordinated Packetization
-In {{overview-hol-avoidance}}, an exception exists when the representation of
-`HA[i]` and `HB[j]` are delivered within the same transport packet.  If so,
-there is no risk of HoL blocking and using an indexed representation is strictly
-better than using a literal.  An implementation could exploit this exception by
-employing co-ordination between QCRAM compression and QUIC transport
-packetization.
+
+When a dynamic table entry is both defined and referenced by header blocks
+within the same packet, there is no risk of HoL blocking and using an indexed
+representation is strictly better than using a literal.  An implementation could
+attempt to exploit this exception by employing co-ordination between QCRAM
+compression and QUIC transport packetization.  However, if the packet is lost,
+the transport might choose a different packetization when retransmitting the
+missing data.
 
 # Security Considerations
 
@@ -322,7 +297,8 @@ TBD.
 
 # IANA Considerations
 
-This document currently makes no request of IANA, and might not need to.
+This document registers a new frame type, HEADER_ACK, for HTTP/QUIC. This will
+need to be added to the IANA Considerations of {{QUIC-HTTP}}.
 
 # Acknowledgments
 


### PR DESCRIPTION
(Builds on #3; ignore changes introduced by that commit.)

The current HEADER_ACK frame doesn't actually work in HTTP/QUIC, since it requires being sent on the same stream on which the header block was received.  In the case of server response headers, the client has already closed the stream; in the case of server push streams, the stream is unidirectional.

This changes the HEADER_ACK to be sent on the control stream and use the variable-length encoding used by other HTTP/QUIC frames.  (I considered using an HPACK 8-bit prefix integer, but that requires reading one byte at a time to find the end of the frame.  The length of a QUIC varint can be determined immediately from the first byte, which is somewhat preferable.)