### PR TITLE
Drop mandatory de-duplication and simplify prefix.

### DIFF
--- a/draft-krasic-quic-qcram.md
+++ b/draft-krasic-quic-qcram.md
@@ -180,7 +180,7 @@ prefix integer:
 
 {{overview-absolute}} describes the role of `Base Index`.
 
-When the BLOCKING flag is 0x1, a the prefix additionally contains a third HPACK
+When the BLOCKING flag is 0x1, a the prefix additionally contains a second HPACK
 integer (8-bit prefix) 'Depends':
 
 ~~~~~~~~~~  drawing


### PR DESCRIPTION
Simplify QCRAM for now.  Can add these back later if wins are
demonstrated.